### PR TITLE
Fix broken link to duckyScript docs in main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ duckyPad Pro has all the basics:
 
 But also features **unlike any other**:
 
-* Custom **[duckyScript](duckyscript_info.md)** engine, **NOT QMK/VIA**.
+* Custom **[duckyScript](doc/duckyscript_info.md)** engine, **NOT QMK/VIA**.
 * **Longer and more complex** macros
 * 1.5" **OLED** screen
 * **Bluetooth**


### PR DESCRIPTION
The link to **duckyScript** in the main README was pointing to `duckyscript_info.md`, not `doc/duckyscript_info.md`. It is quite prominent, the first link in the "Highlights" section.

Another link further down in the same README (in "Table of Contents") does point to the correct page.